### PR TITLE
Add OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,60 @@
       <version>[4.1.0,5.0)</version>
     </dependency>
   </dependencies>
-  
+
+  <build>
+    <plugins>
+      <!-- Produce OSGi manifest -->
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>4.0.0</version>
+        <configuration>
+          <bnd><![CDATA[
+            Bundle-DocURL: ${project.url}
+            Bundle-Name: ${project.name}
+            Bundle-Description: ${project.description}
+            Bundle-SCM: ${project.scm.url}
+            Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+
+            Export-Package: \
+              org.jaudiolibs.jnajack, \
+              org.jaudiolibs.lowlevel
+]]></bnd>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-osgi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Produce jar file with custom manifest -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>release</id>


### PR DESCRIPTION
This adds an execution of the bnd-maven-plugin to add OSGi metadata
to the produced jar files. The metadata is slightly suboptimal in
the case of jna, because jna isn't currently exporting packages with
version numbers.  This means that the dependency on jna will work,
but it will accept more versions of jna than is desirable (you can't
say, for example, that you depend on version 4.5.1 of jna - you'll
just get all of them instead). A future version of jna should correct
this and, when that happens, the metadata here will correct itself
the next time it is generated.

This change has been tested on the Felix OSGi container and appears
to work correctly there.

See https://github.com/java-native-access/jna/issues/975