### PR TITLE
Add isRealtime() method to JackClient

### DIFF
--- a/src/main/java/org/jaudiolibs/jnajack/JackClient.java
+++ b/src/main/java/org/jaudiolibs/jnajack/JackClient.java
@@ -750,6 +750,21 @@ public class JackClient {
         }
     }
 
+    /**
+     * Check if the JACK subsystem is running with -R (--realtime)
+     *
+     * @return true if running in realtime mode
+     * @throws JackException
+     */
+    public boolean isRealtime() throws JackException {
+        try {
+            return jackLib.jack_is_realtime(clientPtr) == 1;
+        } catch (Throwable e) {
+            LOG.log(Level.SEVERE, CALL_ERROR_MSG, e);
+            throw new JackException(e);
+        }
+    }
+
     private void processShutdown() {
 //        clientPtr = null;
         if (userShutdownCallback != null) {


### PR DESCRIPTION
As a software dev myself, I couldn't do this change without a test 😄 

I've add a test class for JackClient, and introduced Mockito and JUnit5.

I also made the Jack class an interface for easier mocking without side effects, but there's a couple of methods used at package level that became public as a consequence of this; setupCTI, forceThreadDetach, which is a little unclean. Also, I didn't add javadoc for those interface methods yet.
I wanted to get some feedback first.

