### PR TITLE
make sure return value from jack_set_sync_callback is assigned

### DIFF
--- a/src/main/java/org/jaudiolibs/jnajack/JackClient.java
+++ b/src/main/java/org/jaudiolibs/jnajack/JackClient.java
@@ -466,7 +466,7 @@ public class JackClient {
 
         int ret = -1;
         try {
-            jackLib.jack_set_sync_callback(clientPtr, wrapper, null);
+            ret = jackLib.jack_set_sync_callback(clientPtr, wrapper, null);
         } catch (Throwable e) {
             LOG.log(Level.SEVERE, CALL_ERROR_MSG, e);
             throw new JackException(e);


### PR DESCRIPTION
The return value of registering the sync callback is ignored and the jnajack library call will always throw a JackException with no message. One cannot register sync callback without this.